### PR TITLE
Fix requirement incompatibility

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   && rm -rf /var/lib/apt/lists/*
 
 ARG POETRY_VERSION
-ENV POETRY_VERSION="${POETRY_VERSION:-1.1.14}"
+ENV POETRY_VERSION="${POETRY_VERSION:-1.4.2}"
 RUN curl -sSL https://install.python-poetry.org \
   | python - --version "${POETRY_VERSION}" \
   && poetry --version


### PR DESCRIPTION
fixes gh action failing duo to cachecontrol requirement incompatibility

see: https://github.com/ionrock/cachecontrol/issues/292