### PR TITLE
scoap3 backend: static files serving with whitenoise

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -90,7 +90,12 @@ AWS_S3_CUSTOM_DOMAIN = env("DJANGO_AWS_S3_CUSTOM_DOMAIN", default=None)
 aws_s3_domain = AWS_S3_CUSTOM_DOMAIN or f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
 # STATIC
 # ------------------------
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
+
 # MEDIA
 # ------------------------------------------------------------------------------
 DEFAULT_FILE_STORAGE = "scoap3.utils.storages.MediaRootS3Boto3Storage"


### PR DESCRIPTION
I hope, that it might fix the issue of serving the static files in production. I noticed that config in settings uses is the old one. 
Starting from Django 4.2 (and we have 4.2.2) it slightly changes:
https://whitenoise.readthedocs.io/en/latest/django.html#add-compression-and-caching-support