### PR TITLE
mail: remove mail verification locally

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -319,10 +319,6 @@ ACCOUNT_ALLOW_REGISTRATION = env.bool("DJANGO_ACCOUNT_ALLOW_REGISTRATION", True)
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
 ACCOUNT_AUTHENTICATION_METHOD = "username"
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
-ACCOUNT_EMAIL_REQUIRED = True
-# https://django-allauth.readthedocs.io/en/latest/configuration.html
-ACCOUNT_EMAIL_VERIFICATION = "mandatory"
-# https://django-allauth.readthedocs.io/en/latest/configuration.html
 ACCOUNT_ADAPTER = "scoap3.users.adapters.AccountAdapter"
 # https://django-allauth.readthedocs.io/en/latest/forms.html
 ACCOUNT_FORMS = {"signup": "scoap3.users.forms.UserSignupForm"}

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -122,6 +122,10 @@ STORAGES = {
 
 # EMAIL
 # ------------------------------------------------------------------------------
+# https://django-allauth.readthedocs.io/en/latest/configuration.html
+ACCOUNT_EMAIL_REQUIRED = True
+# https://django-allauth.readthedocs.io/en/latest/configuration.html
+ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email
 DEFAULT_FROM_EMAIL = env(
     "DJANGO_DEFAULT_FROM_EMAIL",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,15 @@ services:
     networks:
       - djangonetwork
 
+  mailhog:
+    image: mailhog/mailhog:v1.0.0
+    container_name: scoap3_local_mailhog
+    ports:
+      - '8025:8025'
+      - '1025:1025'
+    networks:
+      - djangonetwork
+
 networks:
     djangonetwork:
         driver: bridge


### PR DESCRIPTION
remove e-mail verification for local development so the local mailhog service is not longer needed.