### PR TITLE
Issue #352 ORCID in serializer

### DIFF
--- a/scoap3/articles/api/serializers.py
+++ b/scoap3/articles/api/serializers.py
@@ -112,14 +112,19 @@ class LegacyArticleSerializer(serializers.ModelSerializer):
                     "full_name": entry.full_name,
                     "given_names": entry.first_name,
                     "surname": entry.last_name,
-                    "orcid": {
-                        orcid
-                        for orcid in entry.identifiers.filter(
+                    **(
+                        {
+                            "orcid": entry.identifiers.filter(
+                                identifier_type=AuthorIdentifierType.ORCID
+                            )
+                            .values_list("identifier_value", flat=True)
+                            .first()
+                        }
+                        if entry.identifiers.filter(
                             identifier_type=AuthorIdentifierType.ORCID
-                        )
-                        .values_list("identifier_value", flat=True)
-                        .all()
-                    },
+                        ).exists()
+                        else {}
+                    ),
                 }
                 for entry in obj.authors.all()
             ],

--- a/scoap3/articles/tests/data/workflow_article.json
+++ b/scoap3/articles/tests/data/workflow_article.json
@@ -1,0 +1,65 @@
+{
+    "dois": [{ "value": "10.1103/PhysRevD.110.025020" }],
+    "page_nr": [""],
+    "arxiv_eprints": [{ "value": "2309.15307", "categories": ["hep-th"] }],
+    "authors": [
+      {
+        "full_name": "Nakayama, Yu",
+        "given_names": "Yu",
+        "surname": "Nakayama",
+        "affiliations": [
+          {
+            "value": "Department of Physics, <a href=\"https://ror.org/00x194q47\">Rikkyo University</a>, Toshima, Tokyo 171-8501, Japan and <a href=\"https://ror.org/0589kgd85\">Yukawa Institute for Theoretical Physics</a>, <a href=\"https://ror.org/02kpeqv85\">Kyoto University</a>, Kitashirakawa Oiwakecho, Sakyo-ku, Kyoto 606-8502, Japan",
+            "organization": "Department of Physics, <a href=\"https://ror.org/00x194q47\">Rikkyo University</a>, Toshima, Tokyo 171-8501, Japan and <a href=\"https://ror.org/0589kgd85\">Yukawa Institute for Theoretical Physics</a>, <a href=\"https://ror.org/02kpeqv85\">Kyoto University</a>, Kitashirakawa Oiwakecho, Sakyo-ku, Kyoto 606-8502",
+            "country": "Japan"
+          }
+        ]
+      }
+    ],
+    "license": [
+      {
+        "url": "https://creativecommons.org/licenses/by/4.0/",
+        "license": "CC-BY-4.0"
+      }
+    ],
+    "collections": [
+      { "primary": "HEP" },
+      { "primary": "Citeable" },
+      { "primary": "Published" }
+    ],
+    "publication_info": [
+      {
+        "journal_title": "Physical Review D",
+        "journal_volume": "110",
+        "year": 2024,
+        "journal_issue": "2",
+        "material": "article"
+      }
+    ],
+    "abstracts": [
+      {
+        "value": "<p>A dipolar fixed point introduced by Aharony and Fisher is a physical example of interacting scale-invariant but nonconformal field theories. We find that the perturbative critical exponents computed in <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><mi>ε</mi></math> expansions violate the conformal bootstrap bound. We formulate the functional renormalization group equations <i>à la</i> Wetterich and Polchinski to study the fixed point. We present some results in three dimensions within (uncontrolled) local potential approximations (with or without perturbative anomalous dimensions).</p>",
+        "source": "APS"
+      }
+    ],
+    "acquisition_source": {
+      "source": "APS",
+      "method": "APS",
+      "date": "2024-08-20T19:16:38.813135"
+    },
+    "copyright": [
+      { "year": 2024, "statement": "Published by the American Physical Society" }
+    ],
+    "imprints": [{ "date": "2024-07-23", "publisher": "APS" }],
+    "record_creation_date": "2024-08-20T19:16:38.813135",
+    "titles": [
+      {
+        "title": "Functional renormalization group approach to dipolar fixed point which is scale invariant but nonconformal",
+        "source": "APS"
+      }
+    ],
+    "files": {
+      "pdf": "scoap3-dev-backend/media/harvested_files/10.1103/PhysRevD.110.025020/PhysRevD.110.025020.pdf",
+      "xml": "scoap3-dev-backend/media/harvested_files/10.1103/PhysRevD.110.025020/PhysRevD.110.025020.xml"
+    }
+  }

--- a/scoap3/articles/tests/test_record_views.py
+++ b/scoap3/articles/tests/test_record_views.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from django.urls import reverse
 from rest_framework import status
@@ -56,25 +58,179 @@ class TestRecordViewSet:
         assert "created" in data["results"][0]
 
         metadata = data["results"][0]["metadata"]
-        assert "control_number" in metadata
+
+        assert "_files" in metadata
         assert "abstracts" in metadata
         assert "arxiv_eprints" in metadata
         assert "authors" in metadata
         assert "collections" in metadata
+        assert "control_number" in metadata
+        assert "copyright" in metadata
         assert "dois" in metadata
         assert "imprints" in metadata
         assert "license" in metadata
+        assert "page_nr" in metadata
         assert "publication_info" in metadata
+        assert "record_creation_date" in metadata
         assert "titles" in metadata
 
+    def test_get_record_json_structure_nested(self, client, license, user):
+        client.force_login(user)
+        article = {
+            "title": "string",
+            "related_licenses": [license.id],
+        }
+        response = client.post(
+            reverse("api:article-list"),
+            data=article,
+        )
+        assert response.status_code == 201
+
+        url = reverse("api:records-list")
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.json()
+
+        assert "id" in data["results"][0]
+        assert "metadata" in data["results"][0]
+        assert "updated" in data["results"][0]
+        assert "created" in data["results"][0]
+
+        metadata = data["results"][0]["metadata"]
+
+        assert "_files" in metadata
+        _files = metadata["_files"]
+        assert isinstance(_files, list)
+        if _files:
+            for file in _files:
+                assert "filetype" in file
+                assert "size" in file
+                assert "key" in file
+
+        assert "abstracts" in metadata
+        abstracts = metadata["abstracts"]
+        assert isinstance(abstracts, list)
+        if abstracts:
+            for abstract in abstracts:
+                assert "source" in abstract
+                assert "value" in abstract
+
+        assert "arxiv_eprints" in metadata
+        arxiv_eprints = metadata["arxiv_eprints"]
+        assert isinstance(arxiv_eprints, list)
+        if arxiv_eprints:
+            for eprint in arxiv_eprints:
+                assert "categories" in eprint
+                assert isinstance(eprint["categories"], list)
+                assert "value" in eprint
+                assert isinstance(eprint["value"], list)
+
+        assert "authors" in metadata
         authors = metadata["authors"]
         assert isinstance(authors, list)
         if authors:
             for author in authors:
                 assert "full_name" in author
+                assert "given_names" in author
+                assert "surname" in author
+                assert "orcid" in author
+                assert isinstance(author["orcid"], list)
+
                 assert "affiliations" in author
                 affiliations = author["affiliations"]
+                assert isinstance(affiliations, list)
                 if affiliations:
                     for affiliation in affiliations:
                         assert "country" in affiliation
                         assert "organization" in affiliation
+                        assert "value" in affiliation
+
+        assert "collections" in metadata
+        collections = metadata["collections"]
+        assert isinstance(collections, list)
+        if collections:
+            for collection in collections:
+                assert "primary" in collection
+
+        assert "copyright" in metadata
+        copyright = metadata["copyright"]
+        assert isinstance(copyright, list)
+        if copyright:
+            for item in copyright:
+                assert "statement" in item
+                assert "holder" in item
+                assert "year" in item
+
+        assert "dois" in metadata
+        dois = metadata["dois"]
+        assert isinstance(dois, list)
+        if dois:
+            for doi in dois:
+                assert "value" in doi
+
+        assert "imprints" in metadata
+        imprints = metadata["imprints"]
+        assert isinstance(imprints, list)
+        if imprints:
+            for imprint in imprints:
+                assert "date" in imprint
+                assert "publisher" in imprint
+
+        assert "license" in metadata
+        licenses = metadata["license"]
+        assert isinstance(licenses, list)
+        if licenses:
+            for license in licenses:
+                assert "license" in license
+                assert "url" in license
+
+        assert "page_nr" in metadata
+        assert isinstance(metadata["page_nr"], list)
+
+        assert "publication_info" in metadata
+        publication_info = metadata["publication_info"]
+        assert isinstance(publication_info, list)
+        if publication_info:
+            for info in publication_info:
+                assert "artid" in info
+                assert "journal_issue" in info
+                assert "journal_title" in info
+                assert "journal_volume" in info
+                assert "page_end" in info
+                assert "page_start" in info
+                assert "year" in info
+
+        assert "record_creation_date" in metadata
+
+        assert "titles" in metadata
+        titles = metadata["titles"]
+        assert isinstance(titles, list)
+        if titles:
+            for title in titles:
+                assert "source" in title
+                assert "title" in title
+
+    def test_page_nr_is_int(self, client, license, user, shared_datadir):
+        try:
+            client.force_login(user)
+            contents = (shared_datadir / "workflow_article.json").read_text()
+            data = json.loads(contents)
+
+            response = client.post(
+                reverse("api:article-workflow-import-list"),
+                data,
+                content_type="application/json",
+            )
+            assert response.status_code == status.HTTP_200_OK
+            article_data = response.json()
+            print(article_data)
+
+            url = reverse("api:records-detail", kwargs={"pk": article_data["id"]})
+            response = client.get(url)
+            record_data = response.json()
+            print(record_data)
+
+        except ValueError:
+            pytest.fail("Conversion from string to integer failed")

--- a/scoap3/authors/api/serializers.py
+++ b/scoap3/authors/api/serializers.py
@@ -19,11 +19,19 @@ class AuthorSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
     def get_orcid(self, obj):
-        return {
-            orcid
-            for orcid in obj.identifiers.filter(
-                identifier_type=AuthorIdentifierType.ORCID
+        if obj.identifiers.filter(identifier_type=AuthorIdentifierType.ORCID).exists():
+            return (
+                obj.identifiers.filter(identifier_type=AuthorIdentifierType.ORCID)
+                .values_list("identifier_value", flat=True)
+                .first()
             )
-            .values_list("identifier_value", flat=True)
-            .all()
-        }
+        else:
+            return None
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        if representation.get("orcid") is None:
+            representation.pop("orcid", None)
+
+        return representation

--- a/scoap3/authors/api/serializers.py
+++ b/scoap3/authors/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from scoap3.authors.models import Author, AuthorIdentifier
+from scoap3.authors.models import Author, AuthorIdentifier, AuthorIdentifierType
 from scoap3.misc.api.serializers import AffiliationSerializer
 
 
@@ -12,7 +12,18 @@ class AuthorIdentifierSerializer(serializers.ModelSerializer):
 
 class AuthorSerializer(serializers.ModelSerializer):
     affiliations = AffiliationSerializer(many=True, read_only=True)
+    orcid = serializers.SerializerMethodField()
 
     class Meta:
         model = Author
         fields = "__all__"
+
+    def get_orcid(self, obj):
+        return {
+            orcid
+            for orcid in obj.identifiers.filter(
+                identifier_type=AuthorIdentifierType.ORCID
+            )
+            .values_list("identifier_value", flat=True)
+            .all()
+        }


### PR DESCRIPTION
Added the ORCID fields to /articles and /records by updating the article serializer and the legacy article serializer

#352 (https://github.com/cern-sis/issues-scoap3/issues/352)