### PR TITLE
#366 compliance: find solution for updated articles published <2023

### DIFF
--- a/scoap3/articles/admin.py
+++ b/scoap3/articles/admin.py
@@ -326,7 +326,7 @@ class ArticleAdmin(admin.ModelAdmin):
     def make_compliance_check(self, request, queryset):
         ids = []
         for obj in queryset:
-            compliance_checks.apply_async(args=[obj.id], priority=9)
+            compliance_checks.apply_async(args=[obj.id, True], priority=9)
             ids.append(str(obj.id))
         messages.success(
             request,

--- a/scoap3/articles/tasks.py
+++ b/scoap3/articles/tasks.py
@@ -181,7 +181,7 @@ def check_contains_funded_by_scoap3(article):
 
 
 @shared_task(name="compliance_checks", acks_late=True)
-def compliance_checks(article_id):
+def compliance_checks(article_id, after_update=False):
     if os.getenv("COMPLIANCE_DISABLED", "0") == "1":
         return f"compliance disabled:: article {str(article_id)}"
 
@@ -235,7 +235,7 @@ def compliance_checks(article_id):
         check_contains_funded_by_scoap3=check_funded_by_scoap3_compliance,
         check_contains_funded_by_scoap3_description=check_funded_by_scoap3_description,
     )
-    report.compliant = report.is_compliant()
+    report.compliant = report.is_compliant(after_update)
     report.save()
     logger.info("Compliance checks completed for article %s", article_id)
     return f"Compliance checks completed for article {article_id}"

--- a/scoap3/articles/tests/test_article_compliance.py
+++ b/scoap3/articles/tests/test_article_compliance.py
@@ -278,6 +278,17 @@ class TestArticleCompliance(TestCase):
 
         self.assertEqual(report.compliant, True)
 
+    def test_update_non_compliant_article_published_before_2023(self):
+        compliance_checks(
+            self.article_published_before_2023.id,
+        )
+        report = self.article_published_before_2023.report.first()
+        self.assertEqual(report.compliant, True)
+
+        compliance_checks(self.article_published_before_2023.id, after_update=True)
+        report = self.article_published_before_2023.report.first()
+        self.assertEqual(report.compliant, False)
+
     def test_mark_article_with_reports_as_compliant(self):
         compliance_checks(self.article.id)
         make_compliant(Article.objects.all())


### PR DESCRIPTION
Made it so that compliance_checks receives a parameter in order to determine whether an Article is being updated. If so, it treats articles published before 2023 normally rather than marking them as compliant.

#366 (https://github.com/cern-sis/issues-scoap3/issues/366)