### PR TITLE
#369 articles/admin: Fix ArticleAuthorsInline getters

### DIFF
--- a/scoap3/articles/admin.py
+++ b/scoap3/articles/admin.py
@@ -219,14 +219,12 @@ class ArticleAuthorsInline(admin.StackedInline):
     @admin.display(description="Countries")
     def get_countries(self, obj):
         return ", ".join(
-            [affiliation.country.name for affiliation in obj.affiliation_set.all()]
+            [affiliation.country.name for affiliation in obj.affiliations.all()]
         )
 
     @admin.display(description="Affiliations")
     def get_affiliations(self, obj):
-        return ", ".join(
-            [affiliation.value for affiliation in obj.affiliation_set.all()]
-        )
+        return ", ".join([affiliation.value for affiliation in obj.affiliations.all()])
 
     @admin.display(description="Identifiers")
     def get_identifiers(self, obj):


### PR DESCRIPTION
Used obj.affiliations.all() instead of obj.affiliation_set.all() because the related_name in the affiliation/author relation was set as "affiliations"

Issue #369 (https://github.com/cern-sis/issues-scoap3/issues/369)