### PR TITLE
fix[articles]: fetched filetype from article data

### DIFF
--- a/scoap3/articles/tests/data/legacy_record_pdf_a.json
+++ b/scoap3/articles/tests/data/legacy_record_pdf_a.json
@@ -1,0 +1,99 @@
+{
+  "_updated": "2019-08-01T09:35:25.710805+00:00",
+  "license": [
+    {
+      "url": "http://creativecommons.org/licenses/by/3.0/",
+      "license": "CC-BY-3.0"
+    }
+  ],
+  "copyright": [{ "statement": "The Authors" }],
+  "control_number": "9999",
+  "_oai": {
+    "updated": "2018-04-16T09:24:31Z",
+    "id": "oai:repo.scoap3.org:9999",
+    "sets": ["PLB"]
+  },
+  "authors": [
+    {
+      "surname": "Ballesteros",
+      "given_names": "Angel",
+      "raw_name": "Ballesteros, Angel",
+      "affiliations": [
+        {
+          "country": "Spain",
+          "value": "Departamento de Física, Universidad de Burgos, E-09001 Burgos, Spain"
+        }
+      ],
+      "full_name": "Ballesteros, Angel",
+      "orcid": "0000-0003-4085-3094"
+    },
+    {
+      "surname": "Herranz",
+      "given_names": "Francisco J.",
+      "raw_name": "Herranz, Francisco J.",
+      "affiliations": [
+        {
+          "country": "Spain",
+          "value": "Departamento de Física, Universidad de Burgos, E-09001 Burgos, Spain"
+        }
+      ],
+      "full_name": "Herranz, Francisco J.",
+      "orcid": "0000-0002-5323-616X"
+    },
+    {
+      "raw_name": "Naranjo, Pedro",
+      "affiliations": [
+        {
+          "country": "Spain",
+          "value": "Departamento de Física, Universidad de Burgos, E-09001 Burgos, Spain"
+        }
+      ],
+      "surname": "Naranjo",
+      "given_names": "Pedro",
+      "full_name": "Naranjo, Pedro"
+    }
+  ],
+  "year": "2015",
+  "_files": [
+    {
+      "checksum": "md5:02dd280d11186230f94462d56214deeb",
+      "filetype": "pdf_a",
+      "bucket": "109371f9-38ae-4240-ac32-1e2e7b947248",
+      "version_id": "65caa9d3-2e35-4ba2-b653-0c81ef299eb9",
+      "key": "10.1016/j.physletb.2015.04.041_a.pdf",
+      "size": 688328
+    }
+  ],
+  "record_creation_date": "2015-04-23T00:00:00",
+  "titles": [
+    {
+      "source": "Elsevier",
+      "title": "Towards ( 3+1 ) gravity through Drinfel'd doubles with cosmological constant"
+    }
+  ],
+  "_created": "2018-04-15T00:45:56.757634+00:00",
+  "dois": [{ "value": "10.1016/j.physletb.2015.04.041" }],
+  "publication_info": [
+    {
+      "page_end": "43",
+      "page_start": "37",
+      "material": "article",
+      "journal_title": "Physics Letters B",
+      "year": 2015
+    }
+  ],
+  "$schema": "http://repo.scoap3.org/schemas/hep.json",
+  "abstracts": [
+    {
+      "source": "Elsevier",
+      "value": "We present the generalisation to ( 3+1 ) dimensions of a quantum deformation of the ( 2+1 ) (Anti)-de Sitter and Poincaré Lie algebras that is compatible with the conditions imposed by the Chern–Simons formulation of ( 2+1 ) gravity. Since such compatibility is automatically fulfilled by deformations coming from Drinfel'd double structures, we believe said structures are worth being analysed also in the ( 3+1 ) scenario as a possible guiding principle towards the description of ( 3+1 ) gravity. To this aim, a canonical classical r -matrix arising from a Drinfel'd double structure for the three ( 3+1 ) Lorentzian algebras is obtained. This r -matrix turns out to be a twisted version of the one corresponding to the ( 3+1 ) κ -deformation, and the main properties of its associated noncommutative spacetime are analysed. In particular, it is shown that this new quantum spacetime is not isomorphic to the κ -Minkowski one, and that the isotropy of the quantum space coordinates can be preserved through a suitable change of basis of the quantum algebra generators. Throughout the paper the cosmological constant appears as an explicit parameter, thus allowing the (flat) Poincaré limit to be straightforwardly obtained."
+    }
+  ],
+  "imprints": [{ "date": "2015-04-25", "publisher": "Elsevier" }],
+  "acquisition_source": {
+    "date": "2015-04-23T00:00:00",
+    "source": "Elsevier",
+    "method": "scoap3",
+    "submission_number": "61850faa40f811e881c402163e01809a"
+  }
+}

--- a/scoap3/articles/tests/data/legacy_record_pdf_slash_a.json
+++ b/scoap3/articles/tests/data/legacy_record_pdf_slash_a.json
@@ -1,0 +1,99 @@
+{
+  "_updated": "2019-08-01T09:35:25.710805+00:00",
+  "license": [
+    {
+      "url": "http://creativecommons.org/licenses/by/3.0/",
+      "license": "CC-BY-3.0"
+    }
+  ],
+  "copyright": [{ "statement": "The Authors" }],
+  "control_number": "9999",
+  "_oai": {
+    "updated": "2018-04-16T09:24:31Z",
+    "id": "oai:repo.scoap3.org:9999",
+    "sets": ["PLB"]
+  },
+  "authors": [
+    {
+      "surname": "Ballesteros",
+      "given_names": "Angel",
+      "raw_name": "Ballesteros, Angel",
+      "affiliations": [
+        {
+          "country": "Spain",
+          "value": "Departamento de Física, Universidad de Burgos, E-09001 Burgos, Spain"
+        }
+      ],
+      "full_name": "Ballesteros, Angel",
+      "orcid": "0000-0003-4085-3094"
+    },
+    {
+      "surname": "Herranz",
+      "given_names": "Francisco J.",
+      "raw_name": "Herranz, Francisco J.",
+      "affiliations": [
+        {
+          "country": "Spain",
+          "value": "Departamento de Física, Universidad de Burgos, E-09001 Burgos, Spain"
+        }
+      ],
+      "full_name": "Herranz, Francisco J.",
+      "orcid": "0000-0002-5323-616X"
+    },
+    {
+      "raw_name": "Naranjo, Pedro",
+      "affiliations": [
+        {
+          "country": "Spain",
+          "value": "Departamento de Física, Universidad de Burgos, E-09001 Burgos, Spain"
+        }
+      ],
+      "surname": "Naranjo",
+      "given_names": "Pedro",
+      "full_name": "Naranjo, Pedro"
+    }
+  ],
+  "year": "2015",
+  "_files": [
+    {
+      "checksum": "md5:02dd280d11186230f94462d56214deeb",
+      "filetype": "pdf/a",
+      "bucket": "109371f9-38ae-4240-ac32-1e2e7b947248",
+      "version_id": "65caa9d3-2e35-4ba2-b653-0c81ef299eb9",
+      "key": "10.1016/j.physletb.2015.04.041_a.pdf",
+      "size": 688328
+    }
+  ],
+  "record_creation_date": "2015-04-23T00:00:00",
+  "titles": [
+    {
+      "source": "Elsevier",
+      "title": "Towards ( 3+1 ) gravity through Drinfel'd doubles with cosmological constant"
+    }
+  ],
+  "_created": "2018-04-15T00:45:56.757634+00:00",
+  "dois": [{ "value": "10.1016/j.physletb.2015.04.041" }],
+  "publication_info": [
+    {
+      "page_end": "43",
+      "page_start": "37",
+      "material": "article",
+      "journal_title": "Physics Letters B",
+      "year": 2015
+    }
+  ],
+  "$schema": "http://repo.scoap3.org/schemas/hep.json",
+  "abstracts": [
+    {
+      "source": "Elsevier",
+      "value": "We present the generalisation to ( 3+1 ) dimensions of a quantum deformation of the ( 2+1 ) (Anti)-de Sitter and Poincaré Lie algebras that is compatible with the conditions imposed by the Chern–Simons formulation of ( 2+1 ) gravity. Since such compatibility is automatically fulfilled by deformations coming from Drinfel'd double structures, we believe said structures are worth being analysed also in the ( 3+1 ) scenario as a possible guiding principle towards the description of ( 3+1 ) gravity. To this aim, a canonical classical r -matrix arising from a Drinfel'd double structure for the three ( 3+1 ) Lorentzian algebras is obtained. This r -matrix turns out to be a twisted version of the one corresponding to the ( 3+1 ) κ -deformation, and the main properties of its associated noncommutative spacetime are analysed. In particular, it is shown that this new quantum spacetime is not isomorphic to the κ -Minkowski one, and that the isotropy of the quantum space coordinates can be preserved through a suitable change of basis of the quantum algebra generators. Throughout the paper the cosmological constant appears as an explicit parameter, thus allowing the (flat) Poincaré limit to be straightforwardly obtained."
+    }
+  ],
+  "imprints": [{ "date": "2015-04-25", "publisher": "Elsevier" }],
+  "acquisition_source": {
+    "date": "2015-04-23T00:00:00",
+    "source": "Elsevier",
+    "method": "scoap3",
+    "submission_number": "61850faa40f811e881c402163e01809a"
+  }
+}

--- a/scoap3/articles/tests/data/legacy_record_pdfa.json
+++ b/scoap3/articles/tests/data/legacy_record_pdfa.json
@@ -1,0 +1,99 @@
+{
+  "_updated": "2019-08-01T09:35:25.710805+00:00",
+  "license": [
+    {
+      "url": "http://creativecommons.org/licenses/by/3.0/",
+      "license": "CC-BY-3.0"
+    }
+  ],
+  "copyright": [{ "statement": "The Authors" }],
+  "control_number": "9999",
+  "_oai": {
+    "updated": "2018-04-16T09:24:31Z",
+    "id": "oai:repo.scoap3.org:9999",
+    "sets": ["PLB"]
+  },
+  "authors": [
+    {
+      "surname": "Ballesteros",
+      "given_names": "Angel",
+      "raw_name": "Ballesteros, Angel",
+      "affiliations": [
+        {
+          "country": "Spain",
+          "value": "Departamento de Física, Universidad de Burgos, E-09001 Burgos, Spain"
+        }
+      ],
+      "full_name": "Ballesteros, Angel",
+      "orcid": "0000-0003-4085-3094"
+    },
+    {
+      "surname": "Herranz",
+      "given_names": "Francisco J.",
+      "raw_name": "Herranz, Francisco J.",
+      "affiliations": [
+        {
+          "country": "Spain",
+          "value": "Departamento de Física, Universidad de Burgos, E-09001 Burgos, Spain"
+        }
+      ],
+      "full_name": "Herranz, Francisco J.",
+      "orcid": "0000-0002-5323-616X"
+    },
+    {
+      "raw_name": "Naranjo, Pedro",
+      "affiliations": [
+        {
+          "country": "Spain",
+          "value": "Departamento de Física, Universidad de Burgos, E-09001 Burgos, Spain"
+        }
+      ],
+      "surname": "Naranjo",
+      "given_names": "Pedro",
+      "full_name": "Naranjo, Pedro"
+    }
+  ],
+  "year": "2015",
+  "_files": [
+    {
+      "checksum": "md5:02dd280d11186230f94462d56214deeb",
+      "filetype": "pdfa",
+      "bucket": "109371f9-38ae-4240-ac32-1e2e7b947248",
+      "version_id": "65caa9d3-2e35-4ba2-b653-0c81ef299eb9",
+      "key": "10.1016/j.physletb.2015.04.041_a.pdf",
+      "size": 688328
+    }
+  ],
+  "record_creation_date": "2015-04-23T00:00:00",
+  "titles": [
+    {
+      "source": "Elsevier",
+      "title": "Towards ( 3+1 ) gravity through Drinfel'd doubles with cosmological constant"
+    }
+  ],
+  "_created": "2018-04-15T00:45:56.757634+00:00",
+  "dois": [{ "value": "10.1016/j.physletb.2015.04.041" }],
+  "publication_info": [
+    {
+      "page_end": "43",
+      "page_start": "37",
+      "material": "article",
+      "journal_title": "Physics Letters B",
+      "year": 2015
+    }
+  ],
+  "$schema": "http://repo.scoap3.org/schemas/hep.json",
+  "abstracts": [
+    {
+      "source": "Elsevier",
+      "value": "We present the generalisation to ( 3+1 ) dimensions of a quantum deformation of the ( 2+1 ) (Anti)-de Sitter and Poincaré Lie algebras that is compatible with the conditions imposed by the Chern–Simons formulation of ( 2+1 ) gravity. Since such compatibility is automatically fulfilled by deformations coming from Drinfel'd double structures, we believe said structures are worth being analysed also in the ( 3+1 ) scenario as a possible guiding principle towards the description of ( 3+1 ) gravity. To this aim, a canonical classical r -matrix arising from a Drinfel'd double structure for the three ( 3+1 ) Lorentzian algebras is obtained. This r -matrix turns out to be a twisted version of the one corresponding to the ( 3+1 ) κ -deformation, and the main properties of its associated noncommutative spacetime are analysed. In particular, it is shown that this new quantum spacetime is not isomorphic to the κ -Minkowski one, and that the isotropy of the quantum space coordinates can be preserved through a suitable change of basis of the quantum algebra generators. Throughout the paper the cosmological constant appears as an explicit parameter, thus allowing the (flat) Poincaré limit to be straightforwardly obtained."
+    }
+  ],
+  "imprints": [{ "date": "2015-04-25", "publisher": "Elsevier" }],
+  "acquisition_source": {
+    "date": "2015-04-23T00:00:00",
+    "source": "Elsevier",
+    "method": "scoap3",
+    "submission_number": "61850faa40f811e881c402163e01809a"
+  }
+}

--- a/scoap3/articles/tests/data/workflow_record_with_large_text_pdf_a.json
+++ b/scoap3/articles/tests/data/workflow_record_with_large_text_pdf_a.json
@@ -1,0 +1,65 @@
+{
+  "dois": [{ "value": "10.1103/PhysRevD.110.025020" }],
+  "page_nr": [7],
+  "arxiv_eprints": [{ "value": "2309.15307", "categories": ["hep-th"] }],
+  "authors": [
+    {
+      "full_name": "Nakayama, Yu",
+      "given_names": "Yu",
+      "surname": "Nakayama",
+      "affiliations": [
+        {
+          "value": "Department of Physics, <a href=\"https://ror.org/00x194q47\">Rikkyo University</a>, Toshima, Tokyo 171-8501, Japan and <a href=\"https://ror.org/0589kgd85\">Yukawa Institute for Theoretical Physics</a>, <a href=\"https://ror.org/02kpeqv85\">Kyoto University</a>, Kitashirakawa Oiwakecho, Sakyo-ku, Kyoto 606-8502, Japan",
+          "organization": "Department of Physics, <a href=\"https://ror.org/00x194q47\">Rikkyo University</a>, Toshima, Tokyo 171-8501, Japan and <a href=\"https://ror.org/0589kgd85\">Yukawa Institute for Theoretical Physics</a>, <a href=\"https://ror.org/02kpeqv85\">Kyoto University</a>, Kitashirakawa Oiwakecho, Sakyo-ku, Kyoto 606-8502",
+          "country": "Japan"
+        }
+      ]
+    }
+  ],
+  "license": [
+    {
+      "url": "https://creativecommons.org/licenses/by/4.0/",
+      "license": "CC-BY-4.0"
+    }
+  ],
+  "collections": [
+    { "primary": "HEP" },
+    { "primary": "Citeable" },
+    { "primary": "Published" }
+  ],
+  "publication_info": [
+    {
+      "journal_title": "Physical Review D",
+      "journal_volume": "110",
+      "year": 2024,
+      "journal_issue": "2",
+      "material": "article"
+    }
+  ],
+  "abstracts": [
+    {
+      "value": "<p>A dipolar fixed point introduced by Aharony and Fisher is a physical example of interacting scale-invariant but nonconformal field theories. We find that the perturbative critical exponents computed in <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><mi>ε</mi></math> expansions violate the conformal bootstrap bound. We formulate the functional renormalization group equations <i>à la</i> Wetterich and Polchinski to study the fixed point. We present some results in three dimensions within (uncontrolled) local potential approximations (with or without perturbative anomalous dimensions).</p>",
+      "source": "APS"
+    }
+  ],
+  "acquisition_source": {
+    "source": "APS",
+    "method": "APS",
+    "date": "2024-08-20T19:16:38.813135"
+  },
+  "copyright": [
+    { "year": 2024, "statement": "Published by the American Physical Society" }
+  ],
+  "imprints": [{ "date": "2024-07-23", "publisher": "APS" }],
+  "record_creation_date": "2024-08-20T19:16:38.813135",
+  "titles": [
+    {
+      "title": "Functional renormalization group approach to dipolar fixed point which is scale invariant but nonconformal",
+      "source": "APS"
+    }
+  ],
+  "files": {
+    "pdf_a": "scoap3-dev-backend/media/harvested_files/10.1103/PhysRevD.110.025020/PhysRevD.110.025020.pdf",
+    "xml": "scoap3-dev-backend/media/harvested_files/10.1103/PhysRevD.110.025020/PhysRevD.110.025020.xml"
+  }
+}

--- a/scoap3/articles/tests/data/workflow_record_with_large_text_pdf_slash_a.json
+++ b/scoap3/articles/tests/data/workflow_record_with_large_text_pdf_slash_a.json
@@ -1,0 +1,65 @@
+{
+  "dois": [{ "value": "10.1103/PhysRevD.110.025020" }],
+  "page_nr": [7],
+  "arxiv_eprints": [{ "value": "2309.15307", "categories": ["hep-th"] }],
+  "authors": [
+    {
+      "full_name": "Nakayama, Yu",
+      "given_names": "Yu",
+      "surname": "Nakayama",
+      "affiliations": [
+        {
+          "value": "Department of Physics, <a href=\"https://ror.org/00x194q47\">Rikkyo University</a>, Toshima, Tokyo 171-8501, Japan and <a href=\"https://ror.org/0589kgd85\">Yukawa Institute for Theoretical Physics</a>, <a href=\"https://ror.org/02kpeqv85\">Kyoto University</a>, Kitashirakawa Oiwakecho, Sakyo-ku, Kyoto 606-8502, Japan",
+          "organization": "Department of Physics, <a href=\"https://ror.org/00x194q47\">Rikkyo University</a>, Toshima, Tokyo 171-8501, Japan and <a href=\"https://ror.org/0589kgd85\">Yukawa Institute for Theoretical Physics</a>, <a href=\"https://ror.org/02kpeqv85\">Kyoto University</a>, Kitashirakawa Oiwakecho, Sakyo-ku, Kyoto 606-8502",
+          "country": "Japan"
+        }
+      ]
+    }
+  ],
+  "license": [
+    {
+      "url": "https://creativecommons.org/licenses/by/4.0/",
+      "license": "CC-BY-4.0"
+    }
+  ],
+  "collections": [
+    { "primary": "HEP" },
+    { "primary": "Citeable" },
+    { "primary": "Published" }
+  ],
+  "publication_info": [
+    {
+      "journal_title": "Physical Review D",
+      "journal_volume": "110",
+      "year": 2024,
+      "journal_issue": "2",
+      "material": "article"
+    }
+  ],
+  "abstracts": [
+    {
+      "value": "<p>A dipolar fixed point introduced by Aharony and Fisher is a physical example of interacting scale-invariant but nonconformal field theories. We find that the perturbative critical exponents computed in <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><mi>ε</mi></math> expansions violate the conformal bootstrap bound. We formulate the functional renormalization group equations <i>à la</i> Wetterich and Polchinski to study the fixed point. We present some results in three dimensions within (uncontrolled) local potential approximations (with or without perturbative anomalous dimensions).</p>",
+      "source": "APS"
+    }
+  ],
+  "acquisition_source": {
+    "source": "APS",
+    "method": "APS",
+    "date": "2024-08-20T19:16:38.813135"
+  },
+  "copyright": [
+    { "year": 2024, "statement": "Published by the American Physical Society" }
+  ],
+  "imprints": [{ "date": "2024-07-23", "publisher": "APS" }],
+  "record_creation_date": "2024-08-20T19:16:38.813135",
+  "titles": [
+    {
+      "title": "Functional renormalization group approach to dipolar fixed point which is scale invariant but nonconformal",
+      "source": "APS"
+    }
+  ],
+  "files": {
+    "pdfa": "scoap3-dev-backend/media/harvested_files/10.1103/PhysRevD.110.025020/PhysRevD.110.025020.pdf",
+    "xml": "scoap3-dev-backend/media/harvested_files/10.1103/PhysRevD.110.025020/PhysRevD.110.025020.xml"
+  }
+}

--- a/scoap3/articles/tests/data/workflow_record_with_large_text_pdfa.json
+++ b/scoap3/articles/tests/data/workflow_record_with_large_text_pdfa.json
@@ -1,0 +1,65 @@
+{
+  "dois": [{ "value": "10.1103/PhysRevD.110.025020" }],
+  "page_nr": [7],
+  "arxiv_eprints": [{ "value": "2309.15307", "categories": ["hep-th"] }],
+  "authors": [
+    {
+      "full_name": "Nakayama, Yu",
+      "given_names": "Yu",
+      "surname": "Nakayama",
+      "affiliations": [
+        {
+          "value": "Department of Physics, <a href=\"https://ror.org/00x194q47\">Rikkyo University</a>, Toshima, Tokyo 171-8501, Japan and <a href=\"https://ror.org/0589kgd85\">Yukawa Institute for Theoretical Physics</a>, <a href=\"https://ror.org/02kpeqv85\">Kyoto University</a>, Kitashirakawa Oiwakecho, Sakyo-ku, Kyoto 606-8502, Japan",
+          "organization": "Department of Physics, <a href=\"https://ror.org/00x194q47\">Rikkyo University</a>, Toshima, Tokyo 171-8501, Japan and <a href=\"https://ror.org/0589kgd85\">Yukawa Institute for Theoretical Physics</a>, <a href=\"https://ror.org/02kpeqv85\">Kyoto University</a>, Kitashirakawa Oiwakecho, Sakyo-ku, Kyoto 606-8502",
+          "country": "Japan"
+        }
+      ]
+    }
+  ],
+  "license": [
+    {
+      "url": "https://creativecommons.org/licenses/by/4.0/",
+      "license": "CC-BY-4.0"
+    }
+  ],
+  "collections": [
+    { "primary": "HEP" },
+    { "primary": "Citeable" },
+    { "primary": "Published" }
+  ],
+  "publication_info": [
+    {
+      "journal_title": "Physical Review D",
+      "journal_volume": "110",
+      "year": 2024,
+      "journal_issue": "2",
+      "material": "article"
+    }
+  ],
+  "abstracts": [
+    {
+      "value": "<p>A dipolar fixed point introduced by Aharony and Fisher is a physical example of interacting scale-invariant but nonconformal field theories. We find that the perturbative critical exponents computed in <math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"inline\"><mi>ε</mi></math> expansions violate the conformal bootstrap bound. We formulate the functional renormalization group equations <i>à la</i> Wetterich and Polchinski to study the fixed point. We present some results in three dimensions within (uncontrolled) local potential approximations (with or without perturbative anomalous dimensions).</p>",
+      "source": "APS"
+    }
+  ],
+  "acquisition_source": {
+    "source": "APS",
+    "method": "APS",
+    "date": "2024-08-20T19:16:38.813135"
+  },
+  "copyright": [
+    { "year": 2024, "statement": "Published by the American Physical Society" }
+  ],
+  "imprints": [{ "date": "2024-07-23", "publisher": "APS" }],
+  "record_creation_date": "2024-08-20T19:16:38.813135",
+  "titles": [
+    {
+      "title": "Functional renormalization group approach to dipolar fixed point which is scale invariant but nonconformal",
+      "source": "APS"
+    }
+  ],
+  "files": {
+    "pdfa": "scoap3-dev-backend/media/harvested_files/10.1103/PhysRevD.110.025020/PhysRevD.110.025020.pdf",
+    "xml": "scoap3-dev-backend/media/harvested_files/10.1103/PhysRevD.110.025020/PhysRevD.110.025020.xml"
+  }
+}

--- a/scoap3/articles/tests/test_article_views.py
+++ b/scoap3/articles/tests/test_article_views.py
@@ -58,6 +58,60 @@ class TestArticleViewSet:
             "point which is scale invariant but nonconformal"
         )
 
+    @pytest.mark.parametrize(
+        "file_name",
+        [
+            "workflow_record_with_large_text_pdfa.json",
+            "workflow_record_with_large_text_pdf_a.json",
+            "workflow_record_with_large_text_pdf_slash_a.json",
+        ],
+    )
+    def test_create_article_from_workflow_pdfa_behaviour(
+        self, client, user, shared_datadir, file_name
+    ):
+        client.force_login(user)
+
+        contents = (shared_datadir / file_name).read_text()
+        data = json.loads(contents)
+
+        response = client.post(
+            reverse("api:article-workflow-import-list"),
+            data,
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        article_id = response.data["id"]
+        article = Article.objects.get(id=article_id)
+        assert article.related_files.first().filetype == "pdf/a"
+
+    @pytest.mark.parametrize(
+        "file_name",
+        [
+            "legacy_record_pdfa.json",
+            "legacy_record_pdf_a.json",
+            "legacy_record_pdf_slash_a.json",
+        ],
+    )
+    def test_create_article_from_legacy_pdfa_behaviour(
+        self, client, user, shared_datadir, file_name
+    ):
+        client.force_login(user)
+        contents = (shared_datadir / file_name).read_text()
+        data = json.loads(contents)
+
+        response = client.post(
+            reverse("api:article-workflow-import-list"),
+            data,
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        article_id = response.data["id"]
+        article = Article.objects.get(id=article_id)
+        assert article.related_files.first().filetype == "pdf/a"
+
     def test_create_article_from_legacy(self, client, user, shared_datadir):
         client.force_login(user)
         contents = (shared_datadir / "legacy_record.json").read_text()

--- a/scoap3/tasks.py
+++ b/scoap3/tasks.py
@@ -144,17 +144,35 @@ def _create_article_file(data, article):
         article_id = article.id
         filename = file.get("key")
         file_path = f"files/{article_id}/{filename}"
+        filetype = file.get("filetype", "")
+
+        if filetype in ["pdfa", "pdf/a", "pdf_a"]:
+            filetype = "pdf/a"
+
         article = Article.objects.get(pk=article_id)
-        article_file_data = {"article_id": article, "file": file_path}
+        article_file_data = {
+            "article_id": article,
+            "file": file_path,
+            "filetype": filetype,
+        }
         ArticleFile.objects.get_or_create(**article_file_data)
 
     for file in data.get("files", {}):
         article_id = article.id
         file_path = data["files"][file]
+        filetype = file
+
+        if filetype in ["pdfa", "pdf/a", "pdf_a"]:
+            filetype = "pdf/a"
+
         if DEFAULT_STORAGE_PATH:
             file_path = file_path.replace(DEFAULT_STORAGE_PATH, "")
         article = Article.objects.get(pk=article_id)
-        article_file_data = {"article_id": article, "file": file_path}
+        article_file_data = {
+            "article_id": article,
+            "file": file_path,
+            "filetype": filetype,
+        }
         ArticleFile.objects.get_or_create(**article_file_data)
 
 


### PR DESCRIPTION
Signed-off-by: Lorenzo Vagliano

Also ensured support for different ways to type pdf/a.

Issue #370 (https://github.com/cern-sis/issues-scoap3/issues/370)