### PR TITLE
GH WF: Bump Image update tag to v6.3.1

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -20,9 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: send event
-        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v6.3.0
+        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v6.3.1
         with:
           event-type: update
+          repo: cern-sis/kubernetes-scoap3
           images: |
             cern-sis/scoap3/scoap3-backend@${{ needs.test.outputs.backend-image-id }}
           token: ${{ secrets.PAT_FIRE_EVENTS_ON_CERN_SIS_KUBERNETES_SCOAP3 }}


### PR DESCRIPTION
This will enable sending image update events to the new scoap3 github repo, in turn enabling auto deploying of qa!