### PR TITLE
gh-actions: fix deploy to k8s repo

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -26,4 +26,5 @@ jobs:
           repo: cern-sis/kubernetes-scoap3
           images: |
             cern-sis/scoap3/scoap3-backend@${{ needs.test.outputs.backend-image-id }}
+            cern-sis/scoap3/scoap3-backend-ui@${{ needs.test.outputs.ui-image-id }}
           token: ${{ secrets.PAT_FIRE_EVENTS_ON_CERN_SIS_KUBERNETES_SCOAP3 }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,11 @@ on:
         required: true
     outputs:
       backend-image-id:
-        description: The ID of image that has been buit
+        description: The ID of backend image that has been built
         value: ${{ jobs.build-backend.outputs.image-id }}
+      ui-image-id:
+        description: The ID of ui image that has been built
+        value: ${{ jobs.build-ui.outputs.image-id }}
 
 jobs:
   build-backend:


### PR DESCRIPTION
Currently when deploying the same image id gets used for the backend and the backend-ui image on the k8s repo. This cant works because they get different ids when being build, so we should pass both...