### PR TITLE
gh-actions: bump versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
 
       - id: build
         name: Build and push
-        uses: cern-sis/gh-workflows/.github/actions/docker-build@v6.3.1
+        uses: cern-sis/gh-workflows/.github/actions/docker-build@v7.0.0
         with:
           image: ${{ inputs.image }}
           context: ${{ inputs.context }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: send event
-        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v6.3.1
+        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v7.0.0
         with:
           event-type: update
           repo: cern-sis/kubernetes-scoap3


### PR DESCRIPTION
GitHub Actions has deprecated NodeJS 20 actions.

See more at https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/