### PR TITLE
s3: Fix uploaded file content-type headers

### DIFF
--- a/scoap3/tasks.py
+++ b/scoap3/tasks.py
@@ -2,6 +2,7 @@ import contextlib
 import io
 import json
 import logging
+import mimetypes
 import os
 import re
 
@@ -455,13 +456,27 @@ def fetch_file_and_save_to_s3(url, s3_path):
         response.raise_for_status()  # Raise error for HTTP status codes >= 400
 
         file_content = ContentFile(response.content)
+        content_type = response.headers.get("Content-Type")
+
+        if not content_type or "octet-stream" in content_type:
+            content_type, _ = mimetypes.guess_type(s3_path)
+
+        if not content_type:
+            if s3_path.lower().endswith((".pdf", ".pdfa")):
+                content_type = "application/pdf"
+            elif s3_path.lower().endswith(".xml"):
+                content_type = "application/xml"
+            else:
+                content_type = "binary/octet-stream"
+
+        file_content.content_type = content_type
 
         s3_file = default_storage.save(s3_path, file_content)
-
         s3_url = default_storage.url(s3_file)
 
         print(f"File successfully saved to {s3_url}")
         return s3_url
+
     except requests.exceptions.RequestException as e:
         print(f"Failed to fetch file from URL: {e}")
         return None

--- a/scoap3/tests/cassettes/TestFetchFileAndSaveToS3.test_falls_back_to_binary_octet_stream_for_unknown_extension.yaml
+++ b/scoap3/tests/cassettes/TestFetchFileAndSaveToS3.test_falls_back_to_binary_octet_stream_for_unknown_extension.yaml
@@ -1,0 +1,20 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: https://example.org/files/article.foobar
+  response:
+    body:
+      string: 'raw binary-ish content for testing'
+    headers: {}
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/scoap3/tests/cassettes/TestFetchFileAndSaveToS3.test_falls_back_to_hardcoded_pdf_default_for_pdfa_extension.yaml
+++ b/scoap3/tests/cassettes/TestFetchFileAndSaveToS3.test_falls_back_to_hardcoded_pdf_default_for_pdfa_extension.yaml
@@ -1,0 +1,20 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: https://example.org/files/article.pdfa
+  response:
+    body:
+      string: '%PDF-1.4 fake pdfa content for testing'
+    headers: {}
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/scoap3/tests/cassettes/TestFetchFileAndSaveToS3.test_falls_back_to_mimetypes_guess_when_server_returns_octet_stream.yaml
+++ b/scoap3/tests/cassettes/TestFetchFileAndSaveToS3.test_falls_back_to_mimetypes_guess_when_server_returns_octet_stream.yaml
@@ -1,0 +1,22 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: https://example.org/files/article.pdf
+  response:
+    body:
+      string: '%PDF-1.4 fake pdf content for testing'
+    headers:
+      content-type:
+      - application/octet-stream
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/scoap3/tests/cassettes/TestFetchFileAndSaveToS3.test_uses_content_type_returned_by_server.yaml
+++ b/scoap3/tests/cassettes/TestFetchFileAndSaveToS3.test_uses_content_type_returned_by_server.yaml
@@ -1,0 +1,22 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: https://example.org/files/article.xml
+  response:
+    body:
+      string: '<article><title>Sample article</title></article>'
+    headers:
+      content-type:
+      - text/xml
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/scoap3/tests/test_tasks.py
+++ b/scoap3/tests/test_tasks.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch
+
+import pytest
+from django.core.files.storage import default_storage
+from django.test import TestCase
+
+from scoap3.tasks import fetch_file_and_save_to_s3
+
+
+@pytest.mark.vcr
+class TestFetchFileAndSaveToS3(TestCase):
+    """Integration tests for the content-type resolution added to fix #532.
+
+    Each test replays a recorded HTTP response (via vcrpy) through the real
+    fetch/save flow, and inspects the ``content_type`` that ends up set on
+    the file object handed to storage - this is the attribute django-storages
+    uses to set the S3 object's ``Content-Type`` header.
+    """
+
+    def _save_and_get_content_type(self, url, s3_path):
+        with patch.object(
+            default_storage, "save", wraps=default_storage.save
+        ) as save_spy:
+            result_url = fetch_file_and_save_to_s3(url, s3_path)
+
+        assert result_url is not None
+        saved_content = save_spy.call_args.args[1]
+        return saved_content.content_type
+
+    def test_uses_content_type_returned_by_server(self):
+        content_type = self._save_and_get_content_type(
+            "https://example.org/files/article.xml", "articles/article.xml"
+        )
+        assert content_type == "text/xml"
+
+    def test_falls_back_to_mimetypes_guess_when_server_returns_octet_stream(self):
+        content_type = self._save_and_get_content_type(
+            "https://example.org/files/article.pdf", "articles/article.pdf"
+        )
+        assert content_type == "application/pdf"
+
+    def test_falls_back_to_hardcoded_pdf_default_for_pdfa_extension(self):
+        # ".pdfa" isn't recognised by Python's mimetypes module, so this
+        # exercises the explicit fallback branch rather than the guess.
+        content_type = self._save_and_get_content_type(
+            "https://example.org/files/article.pdfa", "articles/article.pdfa"
+        )
+        assert content_type == "application/pdf"
+
+    def test_falls_back_to_binary_octet_stream_for_unknown_extension(self):
+        content_type = self._save_and_get_content_type(
+            "https://example.org/files/article.foobar", "articles/article.foobar"
+        )
+        assert content_type == "binary/octet-stream"

--- a/ui/src/components/shared/FulltextFiles.tsx
+++ b/ui/src/components/shared/FulltextFiles.tsx
@@ -57,8 +57,8 @@ const FulltextFiles: React.FC<FulltextFilesProps> = ({
               key={file?.file}
               href={file?.file}
               className={`file-${size} mr-2`}
-              download
               target="_blank"
+              rel="noopener noreferrer"
             >
               {icon}
               {label}


### PR DESCRIPTION
* Apply accurate content-type depending on file extension
* ref:  cern-sis/issues-scoap3#532